### PR TITLE
Add ability to rescan blockchain from a certain block height

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -133,6 +133,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getspecialtxes", 2, "count" },
     { "getspecialtxes", 3, "skip" },
     { "getspecialtxes", 4, "verbosity" },
+    { "rescanblockchain", 0, "start_height" },
     // Echo with conversion (For testing only)
     { "echojson", 0, "arg0" },
     { "echojson", 1, "arg1" },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4726,6 +4726,7 @@ UniValue bumpfee(const JSONRPCRequest& request)
 extern UniValue dumpprivkey_tecracoin(const JSONRPCRequest& request); // in rpcdump.cpp
 extern UniValue importprivkey(const JSONRPCRequest& request);
 extern UniValue importaddress(const JSONRPCRequest& request);
+extern UniValue rescanblockchain(const JSONRPCRequest& request);
 extern UniValue importpubkey(const JSONRPCRequest& request);
 extern UniValue dumpwallet(const JSONRPCRequest& request);
 extern UniValue importwallet(const JSONRPCRequest& request);
@@ -4788,6 +4789,8 @@ static const CRPCCommand commands[] =
 
     { "wallet",             "removetxmempool",          &removetxmempool,          false,  {"txid"} },
     { "wallet",             "removetxwallet",           &removetxwallet,           false,  {"txid"} },
+    { "wallet",             "rescanblockchain",         &rescanblockchain,         true,   {"start_height"} },
+
 };
 
 void RegisterWalletRPCCommands(CRPCTable &t)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -704,8 +704,6 @@ private:
 
     std::set<int64_t> setKeyPool;
 
-    int64_t nTimeFirstKey;
-
     /**
      * Private version of AddWatchOnly method which does not accept a
      * timestamp, and which will reset the wallet's nTimeFirstKey value to 1 if
@@ -801,6 +799,8 @@ public:
     CPubKey vchDefaultKey;
 
     std::set<COutPoint> setLockedCoins;
+
+    int64_t nTimeFirstKey;
 
     const CWalletTx* GetWalletTx(const uint256& hash) const;
 


### PR DESCRIPTION
## PR intention
Mandatory: Add a RPC command that will allow users to scan the wallet from transactions starting from a certain block height.